### PR TITLE
Various fixes

### DIFF
--- a/luabind/config.hpp
+++ b/luabind/config.hpp
@@ -70,7 +70,7 @@
 // C code has undefined behavior, lua is written in C).
 
 #ifdef LUABIND_DYNAMIC_LINK
-# if defined (BOOST_WINDOWS)
+# if defined (_WIN32)
 #  ifdef LUABIND_BUILDING
 #   define LUABIND_API __declspec(dllexport)
 #  else

--- a/luabind/detail/call_function.hpp
+++ b/luabind/detail/call_function.hpp
@@ -103,7 +103,7 @@ namespace luabind
 				push_arguments<PolicyList, 1>(L, std::forward<Args>(args)...);
 
 				if(Function(L, sizeof...(Args), 0)) {
-					assert(lua_gettop(L)==top-NumParams+1);
+					assert(lua_gettop(L)==int(top-NumParams+1));
 					call_error(L);
 				}
 				// pops the return values from the function call

--- a/luabind/detail/class_rep.hpp
+++ b/luabind/detail/class_rep.hpp
@@ -203,7 +203,7 @@ namespace luabind { namespace detail
         class_id_map* m_classes;
 	};
 
-	bool is_class_rep(lua_State* L, int index);
+	LUABIND_API bool is_class_rep(lua_State* L, int index);
 
 }}
 

--- a/luabind/detail/format_signature.hpp
+++ b/luabind/detail/format_signature.hpp
@@ -138,9 +138,12 @@ LUABIND_TYPE_TO_STRING(luabind::argument)
 			  , true
 			  , typename meta::pop_front<Signature>::type()
 			);
-			lua_pushstring(L, ")");
-
-			lua_concat(L, static_cast<int>(meta::size<Signature>::value) * 2 + 2);
+            lua_pushstring(L, ")");
+            size_t sz = meta::size<Signature>::value;
+            size_t ncat = sz * 2 + 2;
+            if (sz == 1)
+                ++ncat;
+            lua_concat(L, ncat);
 		}
 
 	} // namespace detail

--- a/src/class_rep.cpp
+++ b/src/class_rep.cpp
@@ -300,7 +300,7 @@ int luabind::detail::class_rep::static_class_gettable(lua_State* L)
 	return 1;
 }
 
-bool luabind::detail::is_class_rep(lua_State* L, int index)
+LUABIND_API bool luabind::detail::is_class_rep(lua_State* L, int index)
 {
 	if (lua_getmetatable(L, index) == 0) return false;
 


### PR DESCRIPTION
Some clarifications:
- ecf8758c: return value type name wasn't concatenated in the end of `format_signature` function if the function being formatted doesn't take arguments.
- a0edbc5: `is_class_rep` is required to inspect exported symbols.
