### PR TITLE
Add missing default converter specialization for char(&)[N]

### DIFF
--- a/luabind/detail/conversion_policies/native_converter.hpp
+++ b/luabind/detail/conversion_policies/native_converter.hpp
@@ -268,6 +268,11 @@ namespace luabind {
 		: default_converter<char const*>
 	{};
 
+    template <std::size_t N>
+    struct default_converter <char(&)[N]>
+        : default_converter<char const*>
+    {};
+
 	template <std::size_t N>
 	struct default_converter <const char(&)[N]>
 		: default_converter<char const*>

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -73,14 +73,14 @@ namespace
 LUABIND_API void add_overload(
     object const& context, char const* name, object const& fn)
 {
-    function_object* f = *touserdata<function_object*>(getupvalue(fn, 1));
+    function_object* f = *touserdata<function_object*>(std::get<1>(getupvalue(fn, 1)));
     f->name = name;
 
     if (object overloads = context[name])
     {
         if (is_luabind_function(overloads) && is_luabind_function(fn))
         {
-            f->next = *touserdata<function_object*>(getupvalue(overloads, 1));
+            f->next = *touserdata<function_object*>(std::get<1>(getupvalue(overloads, 1)));
             f->keepalive = overloads;
         }
     }

--- a/src/function_introspection.cpp
+++ b/src/function_introspection.cpp
@@ -70,7 +70,7 @@ namespace {
 				return NULL;
 			}
 		}
-		return *touserdata<detail::function_object*>(getupvalue(fn, 1));
+		return *touserdata<detail::function_object*>(std::get<1>(getupvalue(fn, 1)));
 	}
 
 	std::string get_function_name(argument const& fn) {


### PR DESCRIPTION
The following example throws `luabind::error` without that converter:

cpp code:
```cpp
char a[256];
*a = 0;
luabind::globals(L)["foo"](s);
```
lua code:
```lua
function foo(s)
end
```
The last commit fixes compilation failure introduced in 44c2f1a.