### PR TITLE
Bugfixes

### DIFF
--- a/luabind/detail/object_rep.hpp
+++ b/luabind/detail/object_rep.hpp
@@ -52,7 +52,6 @@ namespace luabind {
 			void set_instance(instance_holder* instance) { m_instance = instance; }
 
 			void add_dependency(lua_State* L, int index);
-			void release_dependency_refs(lua_State* L);
 
 			std::pair<void*, int> get_instance(class_id target) const
 			{
@@ -99,6 +98,7 @@ namespace luabind {
 			std::aligned_storage<32>::type m_instance_buffer;
 			class_rep* m_classrep; // the class information about this object's type
 			std::size_t m_dependency_cnt; // counts dependencies
+            detail::lua_reference m_dependency_ref; // reference to lua table holding dependency references
 		};
 
 		template<class T>

--- a/luabind/lua_proxy_interface.hpp
+++ b/luabind/lua_proxy_interface.hpp
@@ -235,11 +235,9 @@ namespace luabind {
 			detail::stack_pop pop(interpreter, 1);
 			specialized_converter_policy_n<0, Policies, T, lua_to_cpp> cv;
 
-#ifndef LUABIND_NO_ERROR_CHECKING
 			if(cv.match(interpreter, decorated_type<T>(), -1)<0) {
 				return error_policy.handle_error(interpreter, typeid(T));
 			}
-#endif
 			return cv.to_cpp(interpreter, decorated_type<T>(), -1);
 		}
 

--- a/src/function.cpp
+++ b/src/function.cpp
@@ -73,14 +73,14 @@ namespace
 LUABIND_API void add_overload(
     object const& context, char const* name, object const& fn)
 {
-    function_object* f = *touserdata<function_object*>(getupvalue(fn, 1));
+    function_object* f = *touserdata<function_object*>(std::get<1>(getupvalue(fn, 1)));
     f->name = name;
 
     if (object overloads = context[name])
     {
         if (is_luabind_function(overloads) && is_luabind_function(fn))
         {
-            f->next = *touserdata<function_object*>(getupvalue(overloads, 1));
+            f->next = *touserdata<function_object*>(std::get<1>(getupvalue(overloads, 1)));
             f->keepalive = overloads;
         }
     }

--- a/src/function_introspection.cpp
+++ b/src/function_introspection.cpp
@@ -70,7 +70,7 @@ namespace {
 				return NULL;
 			}
 		}
-		return *touserdata<detail::function_object*>(getupvalue(fn, 1));
+		return *touserdata<detail::function_object*>(std::get<1>(getupvalue(fn, 1)));
 	}
 
 	std::string get_function_name(argument const& fn) {

--- a/src/object_rep.cpp
+++ b/src/object_rep.cpp
@@ -37,7 +37,7 @@ namespace luabind { namespace detail
 	object_rep::object_rep(instance_holder* instance, class_rep* crep)
 		: m_instance(instance)
 		, m_classrep(crep)
-		, m_dependency_cnt(0)
+		, m_dependency_cnt(1)
 	{
 	}
 
@@ -51,27 +51,17 @@ namespace luabind { namespace detail
 
 	void object_rep::add_dependency(lua_State* L, int index)
 	{
-        assert(m_dependency_cnt < sizeof(object_rep));
-
-        void* key = (char*)this + m_dependency_cnt;
-
-        lua_pushlightuserdata(L, key);
+        if (!m_dependency_ref.is_valid())
+        {
+            lua_newtable(L);
+            m_dependency_ref.set(L);
+        }
+        m_dependency_ref.get(L);
         lua_pushvalue(L, index);
-        lua_rawset(L, LUA_REGISTRYINDEX);
-
+        lua_rawseti(L, -2, m_dependency_cnt);
+        lua_pop(L, 1);
         ++m_dependency_cnt;
 	}
-
-    void object_rep::release_dependency_refs(lua_State* L)
-    {
-        for (std::size_t i = 0; i < m_dependency_cnt; ++i)
-        {
-            void* key = (char*)this + i;
-            lua_pushlightuserdata(L, key);
-            lua_pushnil(L);
-            lua_rawset(L, LUA_REGISTRYINDEX);
-        }
-    }
 
     int destroy_instance(lua_State* L)
     {
@@ -90,7 +80,6 @@ namespace luabind { namespace detail
             lua_call(L, 1, 0);
         }
 
-        instance->release_dependency_refs(L);
         instance->~object_rep();
 
         lua_pushnil(L);

--- a/src/open.cpp
+++ b/src/open.cpp
@@ -146,8 +146,6 @@ namespace luabind {
 
         lua_pushcclosure(L, &deprecated_super, 0);
         lua_setglobal(L, "super");
-
-        set_package_preload(L, "luabind.function_introspection", &bind_function_introspection);
     }
 
 } // namespace luabind


### PR DESCRIPTION
- 82554f5 : Provides workaround for issue #22.
- b7b2bdb : Removes function_introspection auto preload because otherwise `luabind::open` can not be called before `luaL_openlibs` (now one have to manually call `luabind::bind_function_introspection`).
- e2a94d3 : Fixes null pointer dereference that occurs in `to_cpp` function when `LUABIND_NO_ERROR_CHECKING` is defined because `cv.match` invokation is disabled by `#ifndef` condition.
