### PR TITLE
tests must only be built if LUABIND_BUILD_TESTING is specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,11 +40,14 @@ include_directories(
 	${LUA_INCLUDE_DIRS})
 
 add_subdirectory(src)
-add_subdirectory(test)
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 	if(LUABIND_BUILD_TESTING)
 		add_subdirectory(test)
 	endif()
 	add_subdirectory(doc)
+else()
+	if(LUABIND_BUILD_TESTING)
+		add_subdirectory(test)
+	endif()
 endif()


### PR DESCRIPTION
Actually tests are always compiled even if building in source and not having tests enabled. It is an unnecessary overhead and actually doesn't compile using Visual Studio 2013, so install doesn't work either.
