### PR TITLE
Fixed C++17 deprecation warnings

### DIFF
--- a/luabind/detail/crtp_iterator.hpp
+++ b/luabind/detail/crtp_iterator.hpp
@@ -1,4 +1,4 @@
-﻿#ifndef LUABIND_CRTP_ITERATOR_HPP_INCLUDED
+#ifndef LUABIND_CRTP_ITERATOR_HPP_INCLUDED
 #define LUABIND_CRTP_ITERATOR_HPP_INCLUDED
 
 #include <iterator>
@@ -7,13 +7,16 @@ namespace luabind {
 	namespace detail {
 
 		template< typename CRTP, typename Category, typename ValueType, typename ReferenceType = ValueType&, typename DifferenceType = ptrdiff_t >
-		class crtp_iterator :
-			public std::iterator<Category, ValueType, DifferenceType, ValueType*, ReferenceType >
+		class crtp_iterator
 		{
 		public:
-			using base_type = std::iterator<Category, ValueType, DifferenceType, ValueType*, ReferenceType >;
+			using iterator_category = Category;
+			using value_type = ValueType;
+			using difference_type = DifferenceType;
+			using pointer = ValueType * ;
+			using reference = ReferenceType;
 
-
+		public:
 			CRTP& operator++()
 			{
 				upcast().increment();
@@ -37,12 +40,12 @@ namespace luabind {
 				return !upcast().equal(rhs);
 			}
 
-			typename base_type::reference operator*()
+			typename reference operator*()
 			{
 				return upcast().dereference();
 			}
 
-			typename base_type::reference operator->()
+			typename reference operator->()
 			{
 				return upcast().dereference();
 			}

--- a/luabind/detail/crtp_iterator.hpp
+++ b/luabind/detail/crtp_iterator.hpp
@@ -40,12 +40,12 @@ namespace luabind {
 				return !upcast().equal(rhs);
 			}
 
-			typename reference operator*()
+			reference operator*()
 			{
 				return upcast().dereference();
 			}
 
-			typename reference operator->()
+			reference operator->()
 			{
 				return upcast().dereference();
 			}


### PR DESCRIPTION
Inheriting from std::iterator is deprecated in C++17. Instead, the class should expose the following 5 types:

* iterator_category 
* value_type 
* difference_type 
* pointer 
* reference